### PR TITLE
Fix broken PICO compile (mismerge of LwIP reintroduction.)

### DIFF
--- a/src/libzt.cpp
+++ b/src/libzt.cpp
@@ -1510,7 +1510,7 @@ namespace ZeroTier {
 /****************************************************************************/
 
 #if defined(STACK_PICO)
-int zts_get_pico_socket(int fd, struct pico_socket *s)
+int zts_get_pico_socket(int fd, struct pico_socket **s)
 {
     int err = 0;
     if(!zt1Service) {


### PR DESCRIPTION
This fixes a compilation error when building with PICO.