### PR TITLE
Fixed potential stack corruption with sprintf

### DIFF
--- a/src/VirtualTap.cpp
+++ b/src/VirtualTap.cpp
@@ -97,9 +97,9 @@ namespace ZeroTier {
 	{
 		vtaps.push_back((void*)this);
 		// set interface name
-		char tmp3[17];
+		char tmp3[64];
 		ifindex = devno;
-		sprintf(tmp3, "libzt%d-%lx", devno++, _nwid);
+		snprintf(tmp3, 64, "libzt%d-%lx", devno++, _nwid);
 		_dev = tmp3;
 		DEBUG_INFO("set VirtualTap interface name to: %s", _dev.c_str());
 		_thread = Thread::start(this);


### PR DESCRIPTION
string representation of _nwid itself could take up 16 bytes,
so 17 is definitely not enough for this format string.
snprintf is used as a panic check for future changes,
so we could get a truncated string instead of stack corruption.