### PR TITLE
Fix struct name in zts_get_*_addr

### DIFF
--- a/src/Controls.cpp
+++ b/src/Controls.cpp
@@ -440,7 +440,7 @@ int zts_deorbit(uint64_t moonWorldId)
 #ifdef SDK_JNI
 #endif
 
-int zts_get_6plane_addr(struct sockaddr_storage *addr, const uint64_t nwid, const uint64_t nodeId)
+int zts_get_6plane_addr(struct zts_sockaddr_storage *addr, const uint64_t nwid, const uint64_t nodeId)
 {
 	if (!addr || !nwid || !nodeId) {
 		return ZTS_ERR_ARG;
@@ -451,7 +451,7 @@ int zts_get_6plane_addr(struct sockaddr_storage *addr, const uint64_t nwid, cons
 	return ZTS_ERR_OK;
 }
 
-int zts_get_rfc4193_addr(struct sockaddr_storage *addr, const uint64_t nwid, const uint64_t nodeId)
+int zts_get_rfc4193_addr(struct zts_sockaddr_storage *addr, const uint64_t nwid, const uint64_t nodeId)
 {
 	if (!addr || !nwid || !nodeId) {
 		return ZTS_ERR_ARG;


### PR DESCRIPTION
This caused a linking error with these functions:
* `struct sockaddr_storage` doesn't exist, so it gets defined inline as an empty struct
* since its a new struct, these function signatures no longer match their decls in ZeroTierSockets.h
* since they don't match and we're in C++ here, they get treated as overloads of the decls in the .h
* overloads need to be mangled, so they get compiled as _Z19zts..., which leaves no def for `zts_get_*_addr`

As an aside, this is one reason to always typedef your structs.