### PR TITLE
Include sys/endian.h in Sockets.cpp for Android

### DIFF
--- a/src/Sockets.cpp
+++ b/src/Sockets.cpp
@@ -24,6 +24,10 @@
 #include "lwip/dns.h"
 #include "lwip/netdb.h"
 
+#if defined(__ANDROID__)
+#include <sys/endian.h>
+#endif
+
 int zts_errno;
 
 namespace ZeroTier {


### PR DESCRIPTION
This resolves `error: use of undeclared identifier 'htons'` on Android.