### PR TITLE
Enable NDK-only builds for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,11 @@ endif()
 # |                                      JNI                                   |
 # ------------------------------------------------------------------------------
 
-if(ZTS_ENABLE_JAVA OR BUILD_ANDROID)
+if(BUILD_ANDROID)
+    option(ZTS_NDK_ONLY "Use C API callbacks on Android" FALSE)
+endif()
+
+if(ZTS_ENABLE_JAVA OR (BUILD_ANDROID AND NOT ZTS_NDK_ONLY))
     message(STATUS "Looking for JNI")
 
     if(BUILD_WIN)


### PR DESCRIPTION
DevilutionX is a C++ app that uses the NDK to port the app to Android. We use the C API callbacks on all platforms so we need a way to avoid marshalling callbacks to Java.