### PR TITLE
CMake: Remove global java include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,6 @@ endif()
 # ------------------------------------------------------------------------------
 # |                             INCLUDE DIRECTORIES                            |
 # ------------------------------------------------------------------------------
-# Temporary measure to test GitHub workflow on Ubuntu
-include_directories(/usr/lib/jvm/java-11-openjdk-amd64/include/linux/)
 # ZeroTier
 include_directories(${ZTO_SRC_DIR})
 include_directories(${ZTO_SRC_DIR}/include)


### PR DESCRIPTION
The addition of this include in https://github.com/zerotier/libzt/commit/0e2f5b6f1e06493af39d1ca870712211c7273168 broke hermetic and cross-compilation builds of libzt.

Example error (from buildroot): ERROR: unsafe header/library path used in cross-compilation: '-I/usr/lib/jvm/java-11-openjdk-amd64/include/linux'