### PR TITLE
Fix warning about function never used

### DIFF
--- a/src/bindings/java/JavaSockets.cxx
+++ b/src/bindings/java/JavaSockets.cxx
@@ -295,7 +295,7 @@ JNIEXPORT jint JNICALL Java_com_zerotier_sockets_ZeroTierNative_zts_1bsd_1read_1
 }
 
 JNIEXPORT jint JNICALL
-Java_com_zerotier_sockets_ZeroTierNative_zts_1bsd_1write__IB(JNIEnv* env, jclass clazz, jint fd, jbyteArray buf)
+Java_com_zerotier_sockets_ZeroTierNative_zts_1bsd_1write(JNIEnv* env, jclass clazz, jint fd, jbyteArray buf)
 {
     void* data = env->GetPrimitiveArrayCritical(buf, NULL);
     int retval = zts_bsd_write(fd, data, env->GetArrayLength(buf));


### PR DESCRIPTION
The practice of appending "__" with type signature allows for references overloaded methods.
But there is only a single zts_bsd_write method, so just remove.