### PR TITLE
fix 'No such file or directory' error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -603,7 +603,7 @@ android-aar()
     CMAKE_FLAGS="-D${CMAKE_SWITCH}=1 -D${CMAKE_SWITCH}=ON"
     cd $ANDROID_PKG_PROJ_DIR
     ./gradlew $GRADLE_ARGS assemble$UPPERCASE_BUILD_TYPE # assembleRelease / assembleDebug
-    cp $ANDROID_PKG_PROJ_DIR/app/build/outputs/aar/*.aar \
+    cp $ANDROID_PKG_PROJ_DIR/app/build/outputs/aar/libzt-$BUILD_TYPE.aar \
         $PKG_OUTPUT_DIR/libzt-$BUILD_TYPE.aar
     cd -
     echo -e "\n - Build cache  : $CACHE_DIR\n - Build output : $BUILD_OUTPUT_DIR\n"

--- a/pkg/android/app/build.gradle
+++ b/pkg/android/app/build.gradle
@@ -46,6 +46,12 @@ android {
             }
         }
     }
+
+    android.libraryVariants.all { variant ->
+        variant.outputs.all { file ->
+            file.outputFileName = "libzt-${variant.buildType.name}.aar"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Using a wildcard in cp was breaking the command when more than 1 file is present
```
brenton@Brentons-MacBook-Air libzt % ./build.sh android-aar "release"

<< build release aar >>

brenton@Brentons-MacBook-Air libzt % 
brenton@Brentons-MacBook-Air libzt % ./build.sh android-aar "debug"  

<< build debug aar >>

...

BUILD SUCCESSFUL in 48s
33 actionable tasks: 28 executed, 5 up-to-date
cp: target '/Users/brenton/development/github/libzt/dist/android-any-android-debug/libzt-debug.aar': No such file or directory
/Users/brenton/development/github/libzt

 - Build cache  : /Users/brenton/development/github/libzt/cache/android-any-android-debug
 - Build output : /Users/brenton/development/github/libzt/dist

0	/Users/brenton/development/github/libzt/dist/android-any-android-debug
brenton@Brentons-MacBook-Air libzt %
```