### PR TITLE
fix unused warnings

### DIFF
--- a/src/Events.cpp
+++ b/src/Events.cpp
@@ -182,11 +182,10 @@ void Events::sendToUser(zts_event_msg_t* msg)
     if (javaCbMethodId) {
         JNIEnv* env;
 #if defined(__ANDROID__)
-        jint rs = jvm->AttachCurrentThread(&env, NULL);
+        jvm->AttachCurrentThread(&env, NULL);
 #else
-        jint rs = jvm->AttachCurrentThread((void**)&env, NULL);
+        jvm->AttachCurrentThread((void**)&env, NULL);
 #endif
-        uint64_t arg = 0;
         uint64_t id = 0;
         if (ZTS_NODE_EVENT(msg->event_code)) {
             id = msg->node ? msg->node->node_id : 0;

--- a/src/NodeService.cpp
+++ b/src/NodeService.cpp
@@ -1061,25 +1061,24 @@ int NodeService::getRouteAtIdx(
         return ZTS_ERR_ARG;
     }
     // target
-    const char* err = NULL;
     struct sockaddr* sa = (struct sockaddr*)&(netState.config.routes[idx].target);
     if (sa->sa_family == AF_INET) {
         struct sockaddr_in* in4 = (struct sockaddr_in*)sa;
-        err = inet_ntop(AF_INET, &(in4->sin_addr), target, ZTS_INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET, &(in4->sin_addr), target, ZTS_INET6_ADDRSTRLEN);
     }
     if (sa->sa_family == AF_INET6) {
         struct sockaddr_in6* in6 = (struct sockaddr_in6*)sa;
-        err = inet_ntop(AF_INET6, &(in6->sin6_addr), target, ZTS_INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET6, &(in6->sin6_addr), target, ZTS_INET6_ADDRSTRLEN);
     }
     // via
     struct sockaddr* sa_via = (struct sockaddr*)&(netState.config.routes[idx].via);
     if (sa_via->sa_family == AF_INET) {
         struct sockaddr_in* in4 = (struct sockaddr_in*)sa_via;
-        err = inet_ntop(AF_INET, &(in4->sin_addr), via, ZTS_INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET, &(in4->sin_addr), via, ZTS_INET6_ADDRSTRLEN);
     }
     if (sa_via->sa_family == AF_INET6) {
         struct sockaddr_in6* in6 = (struct sockaddr_in6*)sa_via;
-        err = inet_ntop(AF_INET6, &(in6->sin6_addr), via, ZTS_INET6_ADDRSTRLEN);
+        inet_ntop(AF_INET6, &(in6->sin6_addr), via, ZTS_INET6_ADDRSTRLEN);
     }
     if (strlen(via) == 0) {
         strncpy(via, "0.0.0.0", 7);

--- a/src/bindings/java/JavaSockets.cxx
+++ b/src/bindings/java/JavaSockets.cxx
@@ -37,7 +37,7 @@ extern JavaVM* jvm;
 
 void java_detach_from_thread()
 {
-    jint rs = jvm->DetachCurrentThread();
+    jvm->DetachCurrentThread();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
libzt/src/bindings/java/JavaSockets.cxx:40:10: warning: unused variable 'rs' [-Wunused-variable]
libzt/src/Events.cpp:185:14: warning: unused variable 'rs' [-Wunused-variable]
libzt/src/Events.cpp:189:18: warning: unused variable 'arg' [-Wunused-variable]
libzt/src/NodeService.cpp:1064:17: warning: variable 'err' set but not used [-Wunused-but-set-variable]