### PR TITLE
fix examples warnings

### DIFF
--- a/examples/c/nonblockingserver.c
+++ b/examples/c/nonblockingserver.c
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     //   zts_bsd_accept(int fd, struct zts_sockaddr* addr, zts_socklen_t* addrlen)
 
     char remote_ipstr[ZTS_INET6_ADDRSTRLEN] = { 0 };
-    unsigned int port = 0;
+    unsigned short port = 0;
     printf("Accepting on listening socket...\n");
     if ((accfd = zts_accept(fd, remote_ipstr, ZTS_INET6_ADDRSTRLEN, &port)) < 0) {
         printf("Error (fd=%d, ret=%d, zts_errno=%d). Exiting.\n", fd, err, zts_errno);

--- a/examples/c/server.c
+++ b/examples/c/server.c
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
     // Can also use traditional: zts_bsd_socket(), zts_bsd_bind(), zts_bsd_listen(), zts_bsd_accept(), etc.
 
     char remote_addr[ZTS_INET6_ADDRSTRLEN] = { 0 };
-    int remote_port = 0;
+    unsigned short remote_port = 0;
     int len = ZTS_INET6_ADDRSTRLEN;
     if ((accfd = zts_tcp_server(local_addr, local_port, remote_addr, len, &remote_port)) < 0) {
         printf("Error (fd=%d, zts_errno=%d). Exiting.\n", accfd, zts_errno);


### PR DESCRIPTION
warning: incompatible pointer types passing 'int *' to parameter of type 'unsigned short *' [-Wincompatible-pointer-types]