### PR TITLE
C# Always report Node ID as 10 characters

### DIFF
--- a/src/bindings/csharp/Node.cs
+++ b/src/bindings/csharp/Node.cs
@@ -553,14 +553,14 @@ namespace ZeroTier.Core
         public string IdString
         {
             get {
-                return _id.ToString("x16").TrimStart('0');
+                return _id.ToString("x10");
             }
         }
 
         public string IdStr
         {
             get {
-                return string.Format("{0}", _id.ToString("x16"));
+                return string.Format("{0}", _id.ToString("x10"));
             }
         }
 


### PR DESCRIPTION
Leading zeroes would be removed previously. #274 

The x16 formats the id as a 16 character hexadecimal number which would then be stripped.  But if the first character is a 0, then this could return 9 or even fewer characters.

x10 should format it correctly as a 10 digit hexadecimal number the first time